### PR TITLE
Remove problem existence conditional from template.

### DIFF
--- a/app/routes/contribute.rb
+++ b/app/routes/contribute.rb
@@ -11,13 +11,21 @@ module ExercismWeb
         active_problems = Trackler.problems.reject(&:deprecated?).sort_by(&:name)
         need_canonical  = active_problems.reject(&:canonical_data_url)
 
-        erb :"contribute/canonical_data", locals: {
-          current_problem: Trackler.problems[slug],
-          implementations: Trackler.implementations[slug],
-          problems: need_canonical,
-          active_problems_count: active_problems.size,
-          canonical_problems_count: [active_problems - need_canonical].size
-        }
+        problem = Trackler.problems[slug]
+
+        if problem.exists?
+          erb :"contribute/canonical_data_for_problem", locals: {
+            problems: need_canonical,
+            current_problem: problem,
+            implementations: Trackler.implementations[slug],
+          }
+        else
+          erb :"contribute/canonical_data", locals: {
+            problems: need_canonical,
+            active_problems_count: active_problems.size,
+            canonical_problems_count: [active_problems - need_canonical].size
+          }
+        end
       end
     end
   end

--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -9,18 +9,10 @@
       <i class="fa fa-caret-right"></i>
       <a href="/contribute/canonical-data">Canonical Data</a>
 
-      <% if current_problem.exists? %>
-        <i class="fa fa-caret-right"></i>
-        <a href="/contribute/canonical-data/<%= current_problem.slug %>"><%= current_problem.name %></a>
-      <% end %>
     </div>
 
     <div class="col-md-8">
-      <% if current_problem.exists? %>
-        <h1><%= current_problem.name %></h1>
-      <% else %>
         <h1>Canonical Data</h1>
-      <% end %>
     </div>
   </div>
 
@@ -30,7 +22,7 @@
         <ul class="nav nav-pills nav-stacked">
 
           <% problems.each do |problem| %>
-            <li class="<%= "active" if problem.slug == current_problem.slug %>">
+            <li>
               <a href="/contribute/canonical-data/<%= problem.slug %>">
                 <%= problem.name %>
               </a>
@@ -42,56 +34,16 @@
     </aside>
 
     <div class="col-md-8 tab-content">
-      <div class="tab-pane active" id="problem-<%= current_problem.slug %>">
-        <% if current_problem.exists? %>
-
-          <% if current_problem.canonical_data_url %>
-            <p>This problem already has a <code>canonical-data.json</code> file. You can view it <a href="<%= current_problem.canonical_data_url %>">here</a>.</p>
-
-          <% else %>
-
-            <p><%= current_problem.blurb %></p>
-            <p>
-            View the full problem description <a href="<%= current_problem.description_url %>">here</a>.
-            </p>
-
-            <p>
-              The process for extracting canonical data is described in the <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#improving-consistency-by-extracting-shared-test-data">Contributing Guide</a>.
-            </p>
-
-
-            <h2>Implementations</h2>
-
-            <p>
-            <%= current_problem.name %> has been implemented in <%= implementations.count %> <%= "track".pluralize(implementations.count) %>:
-            </p>
-
-            <% implementations.each do |implementation| %>
-              <ul>
-                <li>
-                <a href="<%= implementation.git_url %>">
-                    <%= implementation.track.language %>
-                  </a>
-                </li>
-
-              </ul>
-            <% end %>
-
-          <% end %>
-
-        <% else %>
-
+      <div class="tab-pane active" >
           <p>We have a total of <%= active_problems_count %> problems on Exercism. Some are implemented in many language tracks, others are implemented in just a few.</p>
 
           <p>
           To make it easier to port exercises to new language tracks, we're in the process of creating canonical test data for each problem.
           This gets implemented into a file called <code>canonical-data.json</code>. The file lives in <a href="https://github.com/exercism/x-common">exercism/x-common</a> repository, alongside the other common data for the problem.</p>
 
-          <p>So far we've extracted canonical data for <%= canonical_problems_count %> of the <%= active_problems_count %> problems. Just <%= problems.count %> more to go!</p>
+          <p>So far we've extracted canonical data for <%= canonical_problems_count %> of the <%= active_problems_count %> problems. Just <%= problems.size %> more to go!</p>
 
           <p>Want to help out? Pick an exercise from the list in the sidebar, and check out the documentation in <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#improving-consistency-by-extracting-shared-test-data">the contributing guide</a>.</p>
-
-        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/contribute/canonical_data_for_problem.erb
+++ b/app/views/contribute/canonical_data_for_problem.erb
@@ -1,0 +1,77 @@
+<div class="container contribute">
+  <div class="row" style="padding-top: 40px;">
+    <div class="col-md-4">
+      <a href="/"> HOME </a>
+
+      <i class="fa fa-caret-right"></i>
+      <a href="/contribute">Contribute</a>
+
+      <i class="fa fa-caret-right"></i>
+      <a href="/contribute/canonical-data">Canonical Data</a>
+
+      <i class="fa fa-caret-right"></i>
+      <a href="/contribute/canonical-data/<%= current_problem.slug %>"><%= current_problem.name %></a>
+    </div>
+
+    <div class="col-md-8">
+      <h1><%= current_problem.name %></h1>
+    </div>
+  </div>
+
+  <div class="row" style="padding-top: 20px;">
+    <aside role="complementary">
+      <div class="col-md-4">
+        <ul class="nav nav-pills nav-stacked">
+
+          <% problems.each do |problem| %>
+            <li class="<%= "active" if problem.slug == current_problem.slug %>">
+              <a href="/contribute/canonical-data/<%= problem.slug %>">
+                <%= problem.name %>
+              </a>
+            </li>
+          <% end %>
+
+        </ul>
+      </div>
+    </aside>
+
+    <div class="col-md-8 tab-content">
+      <div class="tab-pane active" id="problem-<%= current_problem.slug %>">
+          <% if current_problem.canonical_data_url %>
+            <p>This problem already has a <code>canonical-data.json</code> file. You can view it <a href="<%= current_problem.canonical_data_url %>">here</a>.</p>
+
+          <% else %>
+
+            <p><%= current_problem.blurb %></p>
+            <p>
+            View the full problem description <a href="<%= current_problem.description_url %>">here</a>.
+            </p>
+
+            <p>
+              The process for extracting canonical data is described in the <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#improving-consistency-by-extracting-shared-test-data">Contributing Guide</a>.
+            </p>
+
+
+            <h2>Implementations</h2>
+
+            <p>
+            <%= current_problem.name %> has been implemented in <%= implementations.count %> <%= "track".pluralize(implementations.count) %>:
+            </p>
+
+            <% implementations.each do |implementation| %>
+              <ul>
+                <li>
+                <a href="<%= implementation.git_url %>">
+                    <%= implementation.track.language %>
+                  </a>
+                </li>
+
+              </ul>
+            <% end %>
+
+          <% end %>
+     </div>
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
Remove conditional from template by splitting it into 2 templates.
One for when there is a slug, and one when there is no slug.

Builds on: https://github.com/exercism/exercism.io/pull/3516

The main problem I have with this is that introduces a bunch of duplciation in the template.

There needs to be a few more steps to separate out just the differences.
